### PR TITLE
Feat: Implement major game balance adjustments (XP, Mana, Spells, Eve…

### DIFF
--- a/src/data/eventCards.ts
+++ b/src/data/eventCards.ts
@@ -13,7 +13,7 @@ export const eventCards: EventCard[] = [
     id: 'EVENT_001',
     title: 'Mana Surge',
     description: 'A surge of mana flows through you!',
-    effect: { type: 'GIVE_MANA', value: 50 },
+    effect: { type: 'GIVE_MANA', value: 35 },
   },
   {
     id: 'EVENT_002',

--- a/src/spells.ts
+++ b/src/spells.ts
@@ -34,7 +34,7 @@ export const SPELL_DEFINITIONS: Record<SpellId, SpellDefinition> = {
   RUNE_TRAP: {
     id: 'RUNE_TRAP',
     name: 'Piège Runique',
-    manaCost: 30,
+    manaCost: 35,
     type: 'TERRAIN',
     description: 'Pose un piège sur une case. Le prochain joueur à s\'y arrêter perd 50 Mana.',
   },
@@ -43,12 +43,12 @@ export const SPELL_DEFINITIONS: Record<SpellId, SpellDefinition> = {
     name: 'Bouclier de Mana',
     manaCost: 50,
     type: 'DEFENSIVE',
-    description: 'Annule le prochain sort négatif qui vous cible. Dure 2 tours.',
+    description: 'Annule le prochain sort négatif qui vous cible. Dure 1 tour.',
   },
   ASTRAL_SWAP: {
     id: 'ASTRAL_SWAP',
     name: 'Échange Astral',
-    manaCost: 75,
+    manaCost: 90,
     type: 'STRATEGIC',
     description: 'Échangez votre position avec celle d\'un autre joueur.',
   },

--- a/src/xpUtils.ts
+++ b/src/xpUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * xpUtils.ts
+ * This file contains utility functions related to player experience (XP) and leveling.
+ */
+
+/**
+ * Calculates the total XP required to reach a given level.
+ * Formula: XP_requis = 100 * (level ^ 1.5)
+ *
+ * @param level The level for which to calculate the XP requirement.
+ * @returns The total XP needed to reach that level.
+ */
+export const getXpForLevel = (level: number): number => {
+  if (level <= 0) {
+    return 0; // Or throw an error, depending on desired behavior for invalid levels
+  }
+  // For level 1, XP required is 0, but the formula gives 100.
+  // Let's adjust so level 1 needs 0, level 2 needs 100*(2^1.5) - 100*(1^1.5) effectively.
+  // Or, more simply, the XP displayed is "XP towards next level".
+  // The formula usually means "total XP accumulated to *reach* this level".
+  // Let's assume the mission implies the total XP to reach level L from level 1.
+  // So, XP for level 1 is 100 * (1^1.5) = 100. XP for level 2 is 100 * (2^1.5) approx 282.
+  // The XP to get from level 1 to level 2 would be 282 - 100 = 182.
+
+  // The issue states: "XP_requis = 100 * (niveau ^ 1.5))"
+  // This is typically the XP needed to *complete* that level and advance to the next.
+  // So, to get from level 1 to level 2, you need 100 * (1 ^ 1.5) = 100 XP.
+  // To get from level 2 to level 3, you need 100 * (2 ^ 1.5) approx 283 XP.
+
+  return Math.floor(100 * Math.pow(level, 1.5));
+};


### PR DESCRIPTION
…nts)

This commit introduces a comprehensive set of balancing changes as per Mission Bêta - L'Équilibre des Forces [BETA-BALANCE-001]. The goal is to create a fairer, more stimulating, and rewarding gameplay experience for you.

Key changes include:

I. XP System:
- Defined and implemented an XP requirement formula: XP_requis = 100 * (niveau ^ 1.5) in src/xpUtils.ts.
- Implemented end-of-game XP rewards in src/index.ts (Winner: +150 XP, Loser: +50 XP) with level-up logic.
- Noted placeholder for future quest XP rewards.

II. Mana Economy:
- Implemented Mana rewards for Mini-Games in src/index.ts: MINI_GAME_QUIZ tile grants +20 Mana.
- Adjusted Spell Mana Costs in src/spells.ts:
    - Astral Swap (ASTRAL_SWAP): Cost increased from 75 to 90 Mana.
    - Rune Trap (RUNE_TRAP): Cost increased from 30 to 35 Mana.

III. Spell and Mechanic Balancing:
- Adjusted Spell Effects:
    - Mana Shield (MANA_SHIELD): Duration reduced to 1 turn (src/index.ts and description in src/spells.ts).
    - Blessing of Hangeul (BLESSING_OF_HANGEUL): Mana granted increased to +10 (src/index.ts).
    - Kimchi's Malice (KIMCHIS_MALICE): Mana drained increased to 15 (src/index.ts).
- Implemented Rune Trap Trigger Logic in src/index.ts:
    - Player landing on a trapped tile loses 50 Mana.
    - Trap is removed after activation.
    - Effect takes precedence over standard tile effects.
- Adjusted Event Cards in src/data/eventCards.ts:
    - Mana Surge (EVENT_001): Mana gained reduced from +50 to +35.

These changes aim to address potential imbalances, ensure no single strategy is dominant, and make your progression and resource management more engaging.