### PR TITLE
Define Firestore schema for spellMastery subcollection

### DIFF
--- a/firestore_structure_example.json
+++ b/firestore_structure_example.json
@@ -1,0 +1,27 @@
+{
+  "users": {
+    "user_ABC123": { // Document ID for a user
+      "displayName": "Apprenant Sorcier",
+      "email": "sorcier@korean-party.mag",
+      // ... other user fields
+      "spellMastery": { // Subcollection
+        "word_001": { // Document ID for a rune (e.g., unique word ID)
+          "masteryLevel": 1,
+          "nextReviewDate": "2025-06-28T10:00:00Z", // ISO 8601 format for Timestamp
+          "easeFactor": 2.5,
+          "successfulReviews": 0,
+          "lastReviewed": "2025-06-24T14:30:00Z"  // ISO 8601 format for Timestamp
+        },
+        "word_002": { // Another rune document
+          "masteryLevel": 2,
+          "nextReviewDate": "2025-07-01T09:00:00Z",
+          "easeFactor": 2.6,
+          "successfulReviews": 1,
+          "lastReviewed": "2025-06-25T11:00:00Z"
+        }
+        // ... other rune documents
+      }
+    }
+    // ... other user documents
+  }
+}

--- a/models/spell_mastery.py
+++ b/models/spell_mastery.py
@@ -1,0 +1,13 @@
+from typing import TypedDict
+from datetime import datetime # Firestore Timestamps are often handled as datetime objects in Python
+
+class RuneDocument(TypedDict):
+    """
+    Represents the structure of a Rune document in Firestore
+    within the /users/{userId}/spellMastery/ subcollection.
+    """
+    masteryLevel: int       # Niveau de 1 à 4 (1:Découverte, 4:Gravé)
+    nextReviewDate: datetime  # Prochaine date de révision (pour le SRS)
+    easeFactor: float         # Facteur de facilité (pour l'algorithme SRS) - using float for numbers
+    successfulReviews: int  # Compteur de révisions réussies
+    lastReviewed: datetime    # Date de la dernière révision


### PR DESCRIPTION
This commit introduces the data model for the `spellMastery` subcollection, which will be stored under each user document.

- Defines a TypedDict `RuneDocument` in `models/spell_mastery.py` for the structure of individual rune mastery data.
- Provides an example JSON structure in `firestore_structure_example.json` to illustrate the user and spellMastery documents.

This structure is designed to support the Spaced Repetition System (SRS) for tracking player learning progress of runes (vocabulary words).