### PR TITLE
feat: Setup Firestore content collections and security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -46,12 +46,28 @@ service cloud.firestore {
     //   allow read, write: if request.auth != null && request.auth.uid == userId;
     // }
 
-    // Quest System Rules
-    // Quest definitions are public to read for authenticated users, write by admin only (via console/SDK admin)
+    // Rules for Game Content Collections (read-only for clients)
+    match /koreanContentBible/{wordId} {
+      allow read: if request.auth != null;
+      allow write: if false; // Content managed by Observatory only
+    }
     match /questDefinitions/{questId} {
       allow read: if request.auth != null;
-      allow write: if false; // Managed by admin/backend
+      allow write: if false; // Content managed by Observatory only
     }
+    match /spellDefinitions/{spellId} {
+      allow read: if request.auth != null;
+      allow write: if false; // Content managed by Observatory only
+    }
+    match /syllablePuzzles/{puzzleId} {
+      allow read: if request.auth != null;
+      allow write: if false; // Content managed by Observatory only
+    }
+    match /foodItemDefinitions/{itemId} {
+      allow read: if request.auth != null;
+      allow write: if false; // Content managed by Observatory only
+    }
+    // Add other content collections here following the same pattern
 
     // Player's quest data
     match /playerQuests/{userId} {

--- a/foodItemDefinitions.json
+++ b/foodItemDefinitions.json
@@ -1,0 +1,44 @@
+[
+  {
+    "hangeul": "김치",
+    "french_name": "Kimchi",
+    "category": "plat",
+    "imageUrl": "/assets/images/food/kimchi.png",
+    "audioUrl": "/assets/audio/food/kimchi.mp3"
+  },
+  {
+    "hangeul": "비빔밥",
+    "french_name": "Bibimbap",
+    "category": "plat",
+    "imageUrl": "/assets/images/food/bibimbap.png",
+    "audioUrl": "/assets/audio/food/bibimbap.mp3"
+  },
+  {
+    "hangeul": "쌀",
+    "french_name": "Riz",
+    "category": "ingredient",
+    "imageUrl": "/assets/images/food/rice.png",
+    "audioUrl": "/assets/audio/food/ssal.mp3"
+  },
+  {
+    "hangeul": "물",
+    "french_name": "Eau",
+    "category": "boisson",
+    "imageUrl": "/assets/images/food/water.png",
+    "audioUrl": "/assets/audio/food/mul.mp3"
+  },
+  {
+    "hangeul": "불고기",
+    "french_name": "Bulgogi",
+    "category": "plat",
+    "imageUrl": "/assets/images/food/bulgogi.png",
+    "audioUrl": "/assets/audio/food/bulgogi.mp3"
+  },
+  {
+    "hangeul": "고추장",
+    "french_name": "Gochujang (Pâte de piment)",
+    "category": "ingredient",
+    "imageUrl": "/assets/images/food/gochujang.png",
+    "audioUrl": "/assets/audio/food/gochujang.mp3"
+  }
+]

--- a/questDefinitions.json
+++ b/questDefinitions.json
@@ -1,0 +1,87 @@
+[
+  {
+    "title": "Le Festin du Débutant",
+    "description": "Prouvez votre connaissance des bases de la cuisine coréenne.",
+    "type": "side",
+    "objective": {
+      "type": "MINIGAME_SCORE",
+      "target": "FOOD_FEAST",
+      "count": 5000
+    },
+    "rewards": {
+      "xp": 150,
+      "mana": 30
+    },
+    "prerequisites": {
+      "level": 5
+    }
+  },
+  {
+    "title": "L'Appel du Marché",
+    "description": "Collectez les ingrédients frais pour un Bibimbap.",
+    "type": "main",
+    "objective": {
+      "type": "COLLECT_ITEM",
+      "target": "INGREDIENT_SET_BIBIMBAP",
+      "count": 1
+    },
+    "rewards": {
+      "xp": 200,
+      "mana": 50,
+      "gold": 100
+    },
+    "prerequisites": {
+      "level": 3,
+      "completedQuest": "INTRO_MARKET_VISIT"
+    }
+  },
+  {
+    "title": "Duel de Syllabes Quotidien",
+    "description": "Remportez une victoire dans l'arène des Syllabes.",
+    "type": "daily",
+    "objective": {
+      "type": "MINIGAME_WINS",
+      "target": "SYLLABLE_BATTLE",
+      "count": 1
+    },
+    "rewards": {
+      "xp": 75,
+      "mana": 20
+    },
+    "prerequisites": {}
+  },
+  {
+    "title": "Pèlerinage à Gyeongbokgung",
+    "description": "Visitez le majestueux palais de Gyeongbokgung.",
+    "type": "event",
+    "objective": {
+      "type": "VISIT_LOCATION",
+      "target": "GYEONGBOKGUNG_PALACE",
+      "count": 1
+    },
+    "rewards": {
+      "xp": 300,
+      "specialItem": "ROYAL_SEAL_FRAGMENT"
+    },
+    "prerequisites": {
+      "level": 10
+    }
+  },
+  {
+    "title": "Maîtrise des Consonnes Doubles",
+    "description": "Atteignez un score élevé au mini-jeu des consonnes.",
+    "type": "side",
+    "objective": {
+      "type": "MINIGAME_SCORE",
+      "target": "DOUBLE_CONSONANT_CHALLENGE",
+      "count": 10000
+    },
+    "rewards": {
+      "xp": 180,
+      "mana": 40
+    },
+    "prerequisites": {
+      "level": 8
+    }
+  }
+]

--- a/spellDefinitions.json
+++ b/spellDefinitions.json
@@ -1,0 +1,47 @@
+[
+  {
+    "spellId": "KARMIC_SWAP",
+    "name": "Échange Karmique",
+    "description": "Échangez votre position sur le plateau avec un autre joueur.",
+    "manaCost": 40,
+    "type": "CHAOS",
+    "target": "opponent",
+    "effectDetails": { "action": "SWAP_POSITION" }
+  },
+  {
+    "spellId": "MANA_SHIELD",
+    "name": "Bouclier de Mana",
+    "description": "Absorbe les 50 prochains points de dégâts de mana.",
+    "manaCost": 25,
+    "type": "DEFENSIVE",
+    "target": "self",
+    "effectDetails": { "action": "APPLY_MANA_SHIELD", "value": 50 }
+  },
+  {
+    "spellId": "SYLLABLE_STUN",
+    "name": "Étourdissement Syllabique",
+    "description": "Force un adversaire à passer son prochain tour de mini-jeu.",
+    "manaCost": 35,
+    "type": "OFFENSIVE",
+    "target": "opponent",
+    "effectDetails": { "action": "MINIGAME_SKIP_TURN" }
+  },
+  {
+    "spellId": "TELEPORT_TO_MARKET",
+    "name": "Téléportation au Marché",
+    "description": "Vous téléporte instantanément à la case Marché la plus proche.",
+    "manaCost": 20,
+    "type": "UTILITY",
+    "target": "self",
+    "effectDetails": { "action": "TELEPORT", "destinationType": "MARKET_TILE" }
+  },
+  {
+    "spellId": "VOCAB_TRAP",
+    "name": "Piège de Vocabulaire",
+    "description": "Pose un piège sur une case. Le prochain joueur à y atterrir doit réussir un test de vocabulaire difficile ou perdre du mana.",
+    "manaCost": 30,
+    "type": "TRAP",
+    "target": "tile",
+    "effectDetails": { "action": "PLACE_TRAP", "trapType": "VOCAB_CHALLENGE" }
+  }
+]

--- a/syllablePuzzles.json
+++ b/syllablePuzzles.json
@@ -1,0 +1,38 @@
+[
+  {
+    "syllable": "글",
+    "jamo": ["ㄱ", "ㅡ", "ㄹ"],
+    "difficulty": 2,
+    "type": "CVC"
+  },
+  {
+    "syllable": "한",
+    "jamo": ["ㅎ", "ㅏ", "ㄴ"],
+    "difficulty": 1,
+    "type": "CVC"
+  },
+  {
+    "syllable": "강",
+    "jamo": ["ㄱ", "ㅏ", "ㅇ"],
+    "difficulty": 2,
+    "type": "CVC"
+  },
+  {
+    "syllable": "꽃",
+    "jamo": ["ㄲ", "ㅗ", "ㅊ"],
+    "difficulty": 3,
+    "type": "CVC"
+  },
+  {
+    "syllable": "위",
+    "jamo": ["ㅇ", "ㅜ", "ㅣ"],
+    "difficulty": 2,
+    "type": "CVV"
+  },
+  {
+    "syllable": "의",
+    "jamo": ["ㅇ", "ㅡ", "ㅣ"],
+    "difficulty": 3,
+    "type": "CVV"
+  }
+]


### PR DESCRIPTION
- Create JSON data files for initial seeding of:
  - questDefinitions
  - spellDefinitions
  - syllablePuzzles
  - foodItemDefinitions
- Update firestore.rules to allow public read (authenticated users) and restrict client write access to these content collections:
  - koreanContentBible
  - questDefinitions
  - spellDefinitions
  - syllablePuzzles
  - foodItemDefinitions